### PR TITLE
Use latest tag of MDK to generate API docs, rather than master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ ENV/
 # mdk-docs
 node_modules
 output
+mdk

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ setup: mainsetup apisetup
 
 ### Implementation:
 
+mdk:
+	git clone https://github.com/datawire/mdk.git
+
 venv:
 	virtualenv venv
 	mkdir node_modules
@@ -34,12 +37,14 @@ maindocs: dist/latest
 	rm -rf dist/latest/main
 	mv main/build/html dist/latest/main
 
-apidocs:
-	quark compile "https://raw.githubusercontent.com/datawire/mdk/master/quark/mdk-2.0.q"
+apidocs: mdk
+        # Switch to latest tag, presumably latest release:
+	cd mdk && git pull && git checkout $$(git describe --abbrev=0 --tags)
+	quark compile mdk/quark/mdk-2.0.q
 	# Use a better Sphinx index page that only includes MDK package API docs:
 	cp -f docs-source-files/index.rst output/py/mdk-2.0/docs
 	javadoc -sourcepath $$(echo output/java/*/src/main/java | sed "s/ /:/g") -subpackages mdk -d dist/latest/java
-	source venv/bin/activate && quark install --python "https://raw.githubusercontent.com/datawire/mdk/master/quark/mdk-2.0.q"
+	source venv/bin/activate && quark install --python mdk/quark/mdk-2.0.q
 	source venv/bin/activate && sphinx-build output/py/mdk-2.0/docs dist/latest/python
 	./node_modules/documentation/bin/documentation.js build --shallow --format html --output dist/latest/javascript output/js/mdk-2.0/mdk
 	rdoc --output dist/latest/ruby output/rb/mdk-2.0/lib/mdk.rb


### PR DESCRIPTION
which may be unreleased code.
